### PR TITLE
Fix number of expected value returned by env.step()

### DIFF
--- a/env/custom_hopper.py
+++ b/env/custom_hopper.py
@@ -15,9 +15,11 @@ class CustomHopper(MujocoEnv, utils.EzPickle):
         MujocoEnv.__init__(self, 4)
         utils.EzPickle.__init__(self)
 
-        self.original_masses = np.copy(self.sim.model.body_mass[1:])    # Default link masses
+        self.original_masses = np.copy(
+            self.sim.model.body_mass[1:])    # Default link masses
 
-        if domain == 'source':  # Source environment has an imprecise torso mass (1kg shift)
+        # Source environment has an imprecise torso mass (1kg shift)
+        if domain == 'source':
             self.sim.model.body_mass[1] -= 1.0
 
 
@@ -35,7 +37,7 @@ class CustomHopper(MujocoEnv, utils.EzPickle):
 
     def get_parameters(self):
         """Get value of mass for each link"""
-        masses = np.array( self.sim.model.body_mass[1:] )
+        masses = np.array(self.sim.model.body_mass[1:])
         return masses
 
     def set_parameters(self, task):
@@ -58,10 +60,11 @@ class CustomHopper(MujocoEnv, utils.EzPickle):
         reward += alive_bonus
         reward -= 1e-3 * np.square(a).sum()
         s = self.state_vector()
-        done = not (np.isfinite(s).all() and (np.abs(s[2:]) < 100).all() and (height > .7) and (abs(ang) < .2))
+        done = not (np.isfinite(s).all() and (
+            np.abs(s[2:]) < 100).all() and (height > .7) and (abs(ang) < .2))
         ob = self._get_obs()
 
-        return ob, reward, done, {}
+        return ob, reward, done, False, {}
 
     def _get_obs(self):
         """Get current state"""
@@ -72,8 +75,10 @@ class CustomHopper(MujocoEnv, utils.EzPickle):
 
     def reset_model(self):
         """Reset the environment to a random initial state"""
-        qpos = self.init_qpos + self.np_random.uniform(low=-.005, high=.005, size=self.model.nq)
-        qvel = self.init_qvel + self.np_random.uniform(low=-.005, high=.005, size=self.model.nv)
+        qpos = self.init_qpos + \
+            self.np_random.uniform(low=-.005, high=.005, size=self.model.nq)
+        qvel = self.init_qvel + \
+            self.np_random.uniform(low=-.005, high=.005, size=self.model.nv)
         self.set_state(qpos, qvel)
         return self._get_obs()
 
@@ -84,27 +89,25 @@ class CustomHopper(MujocoEnv, utils.EzPickle):
         self.viewer.cam.elevation = -20
 
 
-
 """
     Registered environments
 """
 gym.envs.register(
-        id="CustomHopper-v0",
-        entry_point="%s:CustomHopper" % __name__,
-        max_episode_steps=500,
+    id="CustomHopper-v0",
+    entry_point="%s:CustomHopper" % __name__,
+    max_episode_steps=500,
 )
 
 gym.envs.register(
-        id="CustomHopper-source-v0",
-        entry_point="%s:CustomHopper" % __name__,
-        max_episode_steps=500,
-        kwargs={"domain": "source"}
+    id="CustomHopper-source-v0",
+    entry_point="%s:CustomHopper" % __name__,
+    max_episode_steps=500,
+    kwargs={"domain": "source"}
 )
 
 gym.envs.register(
-        id="CustomHopper-target-v0",
-        entry_point="%s:CustomHopper" % __name__,
-        max_episode_steps=500,
-        kwargs={"domain": "target"}
+    id="CustomHopper-target-v0",
+    entry_point="%s:CustomHopper" % __name__,
+    max_episode_steps=500,
+    kwargs={"domain": "target"}
 )
-

--- a/env/mujoco_env.py
+++ b/env/mujoco_env.py
@@ -12,7 +12,8 @@ import gym
 try:
     import mujoco_py
 except ImportError as e:
-    raise error.DependencyNotInstalled("You need to install mujoco_py (https://mujoco.org/)")
+    raise error.DependencyNotInstalled(
+        "You need to install mujoco_py (https://mujoco.org/)")
 
 DEFAULT_SIZE = 500
 
@@ -54,7 +55,7 @@ class MujocoEnv(gym.Env):
         self._set_action_space()
 
         action = self.action_space.sample()
-        observation, _reward, done, _info = self.step(action)
+        observation, _reward, done, _, _info = self.step(action)
         assert not done
 
         self._set_observation_space(observation)
@@ -62,7 +63,8 @@ class MujocoEnv(gym.Env):
         self.seed()
 
     def build_model(self):
-        self.model = mujoco_py.load_model_from_path(os.path.join(os.path.dirname(__file__), "assets/hopper.xml"))
+        self.model = mujoco_py.load_model_from_path(
+            os.path.join(os.path.dirname(__file__), "assets/hopper.xml"))
         self.sim = mujoco_py.MjSim(self.model)
         self.viewer = None
         self._viewers = {}
@@ -107,7 +109,8 @@ class MujocoEnv(gym.Env):
         return ob
 
     def set_state(self, qpos, qvel):
-        assert qpos.shape == (self.model.nq,) and qvel.shape == (self.model.nv,)
+        assert qpos.shape == (
+            self.model.nq,) and qvel.shape == (self.model.nv,)
         old_state = self.sim.get_state()
         new_state = mujoco_py.MjSimState(old_state.time, qpos, qvel,
                                          old_state.act, old_state.udd_state)
@@ -145,14 +148,16 @@ class MujocoEnv(gym.Env):
 
         if mode == 'rgb_array':
             # window size used for old mujoco-py:
-            data = self._get_viewer(mode).read_pixels(width, height, depth=False)
+            data = self._get_viewer(mode).read_pixels(
+                width, height, depth=False)
             # original image is upside-down, so flip it
             return data[::-1, :, :]
         elif mode == 'depth_array':
             self._get_viewer(mode).render(width, height)
             # window size used for old mujoco-py:
             # Extract depth part of the read_pixels() tuple
-            data = self._get_viewer(mode).read_pixels(width, height, depth=True)[1]
+            data = self._get_viewer(mode).read_pixels(
+                width, height, depth=True)[1]
             # original image is upside-down, so flip it
             return data[::-1, :]
         elif mode == 'human':

--- a/test_random_policy.py
+++ b/test_random_policy.py
@@ -11,27 +11,30 @@ What is an action here?
 import gym
 from env.custom_hopper import *
 
+
 def main():
-    render = False
+    render = True
 
     # env = gym.make('CustomHopper-source-v0')  # [2.53429174 3.92699082 2.71433605 5.0893801 ]
-    # env = gym.make('CustomHopper-target-v0')  # [3.53429174 3.92699082 2.71433605 5.0893801 ] 
+    # env = gym.make('CustomHopper-target-v0')  # [3.53429174 3.92699082 2.71433605 5.0893801 ]
     env = gym.make('CustomHopper-source-v0')
 
     print('State space:', env.observation_space)  # state-space
     print('Action space:', env.action_space)  # action-space
-    print('Dynamics parameters:', env.get_parameters())  # masses of each link of the Hopper
+    # masses of each link of the Hopper
+    print('Dynamics parameters:', env.get_parameters())
 
-    n_episodes = 5
+    n_episodes = 500
 
-    for ep in range(n_episodes):  
+    for ep in range(n_episodes):
         done = False
         state = env.reset()  # Reset environment to initial state
 
         while not done:  # Until the episode is over
             action = env.action_space.sample()  # Sample random action
 
-            state, reward, done, info = env.step(action)  # Step the simulator to the next timestep
+            # Step the simulator to the next timestep
+            state, reward, done, _, info = env.step(action)
 
             """Step 4: vision-based
             img_state = env.render(mode="rgb_array", width=224, height=224)


### PR DESCRIPTION
When running `python test_random_policy.py` the following error occurs:

```
Traceback (most recent call last):
  File "test_random_policy.py", line 46, in <module>
    main()
  File "test_random_policy.py", line 35, in main
    state, reward, done, info = env.step(action)  # Step the simulator to the next timestep
  File "/home/user/aml22-rl/.venv/lib/python3.8/site-packages/gym/wrappers/time_limit.py", line 50, in step
    observation, reward, terminated, truncated, info = self.env.step(action)
ValueError: not enough values to unpack (expected 5, got 4)
```

This is due to the number of values returned by `CustomHopper.step` method. This pull request fixes the issue and now `python test_random_policy.py` runs without errors.